### PR TITLE
Create mod for MCPX

### DIFF
--- a/mods/mcpx/formats-data.js
+++ b/mods/mcpx/formats-data.js
@@ -1,0 +1,16 @@
+'use strict';
+
+exports.BattleFormatsData = {
+	vullaby: {
+		inherit: true,
+		tier: 'LC',
+	},
+	ferroseed: {
+		inherit: true,
+		tier: 'LC',
+	},
+	pawniard: {
+		inherit: true,
+		tier: 'LC',
+	},
+};


### PR DESCRIPTION
That is to ease code for allowing Eviolite on LC Pokémon from higher tiers.